### PR TITLE
Only load the file stream on initialization

### DIFF
--- a/lib/tail.ex
+++ b/lib/tail.ex
@@ -34,45 +34,45 @@ defmodule Tail do
 	init callback. Starts the check loop by casting :check to self and then returns the initial state
 	"""
 	def init({file, fun, interval}) do
+		stream = File.stream!(file)
 		GenServer.cast(self, :check)
-    {:ok, {file, fun, interval, nil, 0}}
+    {:ok, {stream, fun, interval, nil, 0}}
 	end
 
 	@doc """
 	Main loop. Calls check_for_lines, sleeps, then continues the loop by casting :check to self
 	and returning with the (possibly updated) last_modified and position
 	"""
-	def handle_cast(:check, {file, fun, interval, last_modified, position}) do
-		{last_modified, position} = check_for_lines(file, fun, last_modified, position)
+	def handle_cast(:check, {stream, fun, interval, last_modified, position}) do
+		{last_modified, position} = check_for_lines(stream, fun, last_modified, position)
 		:timer.sleep(interval)
 		GenServer.cast(self, :check)
-    {:noreply, {file, fun, interval, last_modified, position}}
+    {:noreply, {stream, fun, interval, last_modified, position}}
 	end
 
 	@doc """
 	Handles :kill call. Checks for any final lines before stopping the genserver
 	"""
-	def handle_call(:kill, _from, {file, fun, interval, last_modified, position}) do
-		position = check_for_lines(file, fun, last_modified, position)
-    {:stop, :normal, :ok, {file, fun, interval, last_modified, position}}
+	def handle_call(:kill, _from, {stream, fun, interval, last_modified, position}) do
+		{last_modified, position} = check_for_lines(stream, fun, last_modified, position)
+    {:stop, :normal, :ok, {stream, fun, interval, last_modified, position}}
 	end
 
 	#Crude implementation of line checking. If the file doesn't exist, it simply returns the current state, assuming the
 	#file will appear eventually. If the file hasn't been modified since last time, it also returns the current state.
 	#If the file has been modified, Stream.drop(position) skips lines previously read, then Enum.each applies the
 	#specified function to each line. Returns the new last_modified and position (Enum.count). 
-	defp check_for_lines(file, fun, last_modified, position) do
+	defp check_for_lines(stream, fun, last_modified, position) do
 		cond do
-			!File.exists?(file) ->
+			!File.exists?(stream.path) ->
 				{last_modified, position}
-			File.stat!(file).mtime == last_modified ->
+			File.stat!(stream.path).mtime == last_modified ->
 				{last_modified, position}
 			true ->
-				stream = File.stream!(file)
 				stream
 				|> Stream.drop(position)
 				|> Enum.each(&fun.(&1))
-				{File.stat!(file).mtime, Enum.count(stream)}
+				{File.stat!(stream.path).mtime, Enum.count(stream)}
 		end
 	end
 end


### PR DESCRIPTION
Little bit of an optimization -- only load the File stream when we initialize the gen server, instead of on each iteration.
